### PR TITLE
cython test from using int to double

### DIFF
--- a/cython/test.pyx
+++ b/cython/test.pyx
@@ -1,11 +1,11 @@
 
-cpdef int loop_to(int x):
-    cdef int y = 1
-    cdef int i
+cpdef double loop_to(int x):
+    cdef double y = 1
+    cdef double i
     for i in range(1, x+1):
         y *= i
 
-cpdef void run(int count_test, int number):
-    cdef int i
+cpdef void run(int count_test,  int number):
+    cdef double i
     for i in range(count_test):
         loop_to(number)


### PR DESCRIPTION
### this PRs changes operands types from int to double in order to make the test more accurate